### PR TITLE
docs(scraping): usar XPath en ejemplo Scrapy

### DIFF
--- a/contenidos/_static/code/scraping/books_scraper/spiders/books.py
+++ b/contenidos/_static/code/scraping/books_scraper/spiders/books.py
@@ -48,7 +48,7 @@ class BooksSpider(scrapy.Spider):
         self.logger.info(f"Procesando página: {response.url}")
 
         # Extraer todos los libros de la página
-        books = response.css("article.product_pod")
+        books = response.xpath("//article[contains(@class,'product_pod')]")
         self.logger.info(f"Encontrados {len(books)} libros en esta página")
 
         for book in books:
@@ -57,7 +57,7 @@ class BooksSpider(scrapy.Spider):
                 yield item
 
         # Seguir a la siguiente página si existe
-        next_page = response.css("li.next a::attr(href)").get()
+        next_page = response.xpath("//li[contains(@class,'next')]/a/@href").get()
         if next_page:
             next_page_url = response.urljoin(next_page)
             self.logger.info(f"Siguiendo a siguiente página: {next_page_url}")
@@ -82,13 +82,13 @@ class BooksSpider(scrapy.Spider):
             item = BookItem()
 
             # Extraer título
-            title = book_selector.css("h3 a::attr(title)").get()
+            title = book_selector.xpath(".//h3/a/@title").get()
             if not title:
-                title = book_selector.css("h3 a::text").get()
+                title = book_selector.xpath(".//h3/a/text()").get()
             item["title"] = title.strip() if title else None
 
             # Extraer precio
-            price_text = book_selector.css("p.price_color::text").get()
+            price_text = book_selector.xpath(".//p[contains(@class,'price_color')]/text()").get()
             if price_text:
                 # Remover el símbolo de libra y espacios
                 price_clean = price_text.replace("£", "").strip()
@@ -97,7 +97,7 @@ class BooksSpider(scrapy.Spider):
                 item["price"] = None
 
             # Extraer disponibilidad
-            availability = book_selector.css("p.instock.availability::text").getall()
+            availability = book_selector.xpath(".//p[contains(@class,'instock') and contains(@class,'availability')]/text()").getall()
             if availability:
                 # Unir todos los textos y limpiar espacios
                 availability_text = "".join(availability).strip()
@@ -106,7 +106,7 @@ class BooksSpider(scrapy.Spider):
                 item["availability"] = "Unknown"
 
             # Extraer calificación
-            rating_class = book_selector.css("p.star-rating::attr(class)").get()
+            rating_class = book_selector.xpath(".//p[contains(@class,'star-rating')]/@class").get()
             if rating_class:
                 # La clase contiene algo como "star-rating Three"
                 rating_parts = rating_class.split()
@@ -119,7 +119,7 @@ class BooksSpider(scrapy.Spider):
                 item["rating"] = "Unknown"
 
             # Extraer URL relativa del libro
-            book_url = book_selector.css("h3 a::attr(href)").get()
+            book_url = book_selector.xpath(".//h3/a/@href").get()
             if book_url:
                 # Convertir URL relativa a absoluta
                 item["url"] = response.urljoin(book_url)
@@ -154,16 +154,16 @@ class BooksSpider(scrapy.Spider):
         book_item = response.meta.get("book_item")
 
         # Extraer información adicional de la página del libro
-        description = response.css("#product_description + p::text").get()
+        description = response.xpath("//*[@id='product_description']/following-sibling::p[1]/text()").get()
         if description:
             book_item["description"] = description.strip()
 
         # Extraer información de la tabla de producto
         product_info = {}
-        rows = response.css("table.table-striped tr")
+        rows = response.xpath("//table[contains(@class,'table-striped')]//tr")
         for row in rows:
-            key = row.css("td:first-child::text").get()
-            value = row.css("td:last-child::text").get()
+            key = row.xpath('.//td[1]//text()').get()
+            value = row.xpath('.//td[last()]//text()').get()
             if key and value:
                 product_info[key.strip()] = value.strip()
 


### PR DESCRIPTION
Actualiza el ejemplo del spider para usar selectores XPath en lugar de selectores CSS y actualiza el apunte para mostrar la versión con XPath. Closes #15.